### PR TITLE
Исправил баг с пробелом и заглавными буквами

### DIFF
--- a/Translation_Transcription_Docs_Creator/Unpacked Extension/index.js
+++ b/Translation_Transcription_Docs_Creator/Unpacked Extension/index.js
@@ -113709,7 +113709,7 @@ function translate(){
     // перевод с помощью yandexTranslate
     yandexTranslate.translate(word, {to: 'ru'}, function (err,res) {
         let trans = res.text[0];
-        document.getElementById('transcription').value = TextToIPA.lookup(word).text;
+        document.getElementById('transcription').value = TextToIPA.lookup(word.toLowerCase().replace(" ","")).text;
         document.getElementById("translation").value = trans;
     })
 }

--- a/Translation_Transcription_Docs_Creator/Unpacked Extension/script.js
+++ b/Translation_Transcription_Docs_Creator/Unpacked Extension/script.js
@@ -154,7 +154,7 @@ function translate(){
     // перевод с помощью yandexTranslate
     yandexTranslate.translate(word, {to: 'ru'}, function (err,res) {
         let trans = res.text[0];
-        document.getElementById('transcription').value = TextToIPA.lookup(word).text;
+        document.getElementById('transcription').value = TextToIPA.lookup(word.toLowerCase().replace(" ","")).text;
         document.getElementById("translation").value = trans;
     })
 }


### PR DESCRIPTION
Был баг, при котором не выводилась транскрипция, если слово начиналось с заглавной буквы или заканчивалось пробелом. Пофиксил.